### PR TITLE
removing broken logger

### DIFF
--- a/lib/avst-cloud/rackspace_connection.rb
+++ b/lib/avst-cloud/rackspace_connection.rb
@@ -176,7 +176,6 @@ module AvstCloud
                 if hdd.state == expected_state
                     break
                 end
-                logger.debug(.)
                 sleep 60
             end
         end


### PR DESCRIPTION
removing this allows the cloud-runner to work, with it, it fails.